### PR TITLE
Include unistd.h to use sleep() etc.

### DIFF
--- a/Common/FeeCtrl/SitcpController.cc
+++ b/Common/FeeCtrl/SitcpController.cc
@@ -8,6 +8,7 @@
 #include<cstdio>
 #include<csignal>
 #include<string>
+#include<unistd.h>
 
 namespace RBCP{
 

--- a/HulCore/DaqFuncs.cc
+++ b/HulCore/DaqFuncs.cc
@@ -4,6 +4,7 @@
 #include<cstdio>
 #include<csignal>
 #include<list>
+#include<unistd.h>
 
 #include<arpa/inet.h>
 #include<sys/types.h>


### PR DESCRIPTION
DaqFuncs.ccにおいてsleep(), close()が、SitcpController.ccにおいてusleep()が利用できなかったので、両ファイル中でunistd.hをincludeした